### PR TITLE
Update MPU9250.cpp

### DIFF
--- a/C++/Navio/MPU9250.cpp
+++ b/C++/Navio/MPU9250.cpp
@@ -123,7 +123,7 @@ bool MPU9250::initialize(int sample_rate_div, int low_pass_filter)
 
     for(i=0; i<MPU_InitRegNum; i++) {
         WriteReg(MPU_Init_Data[i][1], MPU_Init_Data[i][0]);
-        usleep(10000);  //I2C must slow down the write speed, otherwise it won't work
+        usleep(100000);  //I2C must slow down the write speed, otherwise it won't work
     }
 
     set_acc_scale(BITS_FS_16G);

--- a/C++/Navio/MPU9250.cpp
+++ b/C++/Navio/MPU9250.cpp
@@ -86,13 +86,13 @@ BITS_DLPF_CFG_2100HZ_NOLPF
 returns 1 if an error occurred
 -----------------------------------------------------------------------------------------------*/
 
-#define MPU_InitRegNum 17
+#define MPU_InitRegNum 16
 
 bool MPU9250::initialize(int sample_rate_div, int low_pass_filter)
 {
     uint8_t i = 0;
     uint8_t MPU_Init_Data[MPU_InitRegNum][2] = {
-        {0x80, MPUREG_PWR_MGMT_1},     // Reset Device
+        //{0x80, MPUREG_PWR_MGMT_1},     // Reset Device - Disabled because it seems to corrupt initialisation of AK8963
         {0x01, MPUREG_PWR_MGMT_1},     // Clock Source
         {0x00, MPUREG_PWR_MGMT_2},     // Enable Acc & Gyro
         {low_pass_filter, MPUREG_CONFIG},         // Use DLPF set Gyroscope bandwidth 184Hz, temperature bandwidth 188Hz


### PR DESCRIPTION
Prevent reseting the MPU9250, because it may corrupt AK8963's initialisation.